### PR TITLE
[DCB] migrate to Play 13

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -167,8 +167,3 @@ timeout {
 claimRefund {
     url = "https://www.tax.service.gov.uk/report-quarterly/income-and-expenses/view/money-in-your-account"
 }
-
-play-frontend-hmrc {
-   useRebrand = true
-   forceServiceNavigation = true
-}

--- a/conf/messages
+++ b/conf/messages
@@ -110,7 +110,7 @@ refundApproved.reference = Refund reference: {0}
 refundApproved.p1.unknown = We have approved your refund of {0} and sent it for payment.
 refundApproved.p1.card = We have approved your refund of {0} and sent it to the card you used to pay your last Simple Assessment bill.
 refundApproved.p1.bacs = We have approved your refund of {0} and sent it to the bank account you shared with us.
-refundApproved.p1.po = We have approved your refund of {0} and sent it to to you by cheque.
+refundApproved.p1.po = We have approved your refund of {0} and sent it to you by cheque.
 refundApproved.p2 = You should receive your refund by {0}.
 refundApproved.moreDetails = More details about this refund
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
   val compile: Seq[ModuleID] = Seq(
     // format: OFF
     "uk.gov.hmrc"    %% "bootstrap-frontend-play-30"            % bootstrapVersion,
-    "uk.gov.hmrc"    %% "play-frontend-hmrc-play-30"            % "12.32.0",
+    "uk.gov.hmrc"    %% "play-frontend-hmrc-play-30"            % "13.0.0",
     "org.typelevel"  %% "cats-core"                             % "2.13.0",
     "uk.gov.hmrc"    %% "play-conditional-form-mapping-play-30" % "3.5.0",
     "com.beachape"   %% "enumeratum-play"                       % "1.9.6",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("com.github.sbt"     % "sbt-gzip"            % "2.0.0")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"         % "0.6.4")
-addSbtPlugin("io.github.irundaia" % "sbt-sassify"         % "1.5.2")
+addSbtPlugin("uk.gov.hmrc"        % "sbt-sass-compiler"   % "0.12.0")
 addSbtPlugin("org.playframework"  % "sbt-plugin"          % "3.0.10")
 addSbtPlugin("org.scalameta"      % "sbt-scalafmt"        % "2.4.0")
 addSbtPlugin("org.scoverage"      % "sbt-scoverage"       % "2.4.0")

--- a/test/uk/gov/hmrc/selfassessmentrefundfrontend/controllers/trackRefundJourney/RefundApprovedControllerSpec.scala
+++ b/test/uk/gov/hmrc/selfassessmentrefundfrontend/controllers/trackRefundJourney/RefundApprovedControllerSpec.scala
@@ -250,7 +250,7 @@ class RefundApprovedControllerSpec extends ItSpec with PageContentTesting {
     if (method == "BACS") "We have approved your refund of £12,000 and sent it to the bank account you shared with us."
     else if (method == "CARD")
       "We have approved your refund of £12,000 and sent it to the card you used to pay your last Simple Assessment bill."
-    else if (method == "PO") "We have approved your refund of £12,000 and sent it to to you by cheque."
+    else if (method == "PO") "We have approved your refund of £12,000 and sent it to you by cheque."
     else "We have approved your refund of £12,000 and sent it for payment.",
     "You should receive your refund by 31 August 2021."
   )


### PR DESCRIPTION
Followed migration guide from here: https://docs.google.com/document/d/11ON60vRgDVSTbYmuTB03CWCPmGKgB_VEailS07G9vMY/edit?tab=t.0 

We were mostly in line already with the requirements and the service is already rebranded.

Follows on from previous PR: https://github.com/hmrc/self-assessment-refund-frontend/pull/31 
